### PR TITLE
BAN-4023 - Adding PR template for github organization

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,16 @@
+Description: 
+- {Please describe the change-set, what is implemented/fixed and how?  2-3 lines should be good enough} 
+
+Team:
+- {The author team/service owner team}
+
+Relevant Story/Bug:
+- {JIRA-ID}
+
+Testing Done: 
+- {This should state, mechanism of the testing like In-progress via Sandbox  etc.}
+
+Dependent PRs: 
+- {Other PR connected to this feature - if there are any.
+   It's advisable to create optimal sized multiple PRs for a feature instead of single consolidated.
+   } 


### PR DESCRIPTION
Description: 
- The template for Pull Requests has been added. This template will be reflected to all repositories in **fintechinnovationas** organization.

Team:
- DevOps

Relevant Story/Bug:
- BAN-4023

Testing Done: 
- {This should state, mechanism of the testing like In-progress via Sandbox  etc.}

Dependent PRs: 
- N/A
